### PR TITLE
feat: 新增 Dark/Light Mode 主題切換與圖片色彩反轉功能

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -17,9 +17,41 @@
     --color-border: #e2e8f0;
     --color-success: #16a34a;
     --color-error: #dc2626;
+    --color-table-hover: #eef2ff;
+    --color-dropzone-active: #eff6ff;
+    --color-danger-hover: #b91c1c;
     --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans TC", sans-serif;
     --font-mono: "Fira Code", "Cascadia Code", Consolas, monospace;
     --navbar-height: 56px;
+    color-scheme: light;
+}
+
+/* === Dark Mode 主題覆蓋 === */
+[data-theme="dark"] {
+    --color-primary: #3b82f6;
+    --color-primary-hover: #60a5fa;
+    --color-bg: #0f172a;
+    --color-surface: #1e293b;
+    --color-text: #f1f5f9;
+    --color-text-secondary: #94a3b8;
+    --color-border: #334155;
+    --color-success: #22c55e;
+    --color-error: #ef4444;
+    --color-table-hover: #1e3a5f;
+    --color-dropzone-active: #172554;
+    --color-danger-hover: #dc2626;
+    color-scheme: dark;
+}
+
+/* Dark Mode 語義色彩元件覆蓋 */
+[data-theme="dark"] .type-image {
+    background-color: #1e3a5f;
+    color: #93c5fd;
+}
+
+[data-theme="dark"] .type-markdown {
+    background-color: #14532d;
+    color: #86efac;
 }
 
 html, body {
@@ -299,6 +331,11 @@ main {
     max-width: 100%;
     max-height: 100%;
     object-fit: contain;
+    transition: filter 0.3s ease;
+}
+
+#preview-image.inverted {
+    filter: invert(1);
 }
 
 /* === 右面板 Markdown 編輯區 === */
@@ -521,7 +558,7 @@ main {
 }
 
 .browser-table tbody tr:hover {
-    background-color: #eef2ff;
+    background-color: var(--color-table-hover);
 }
 
 /* 類型標籤 */
@@ -610,7 +647,7 @@ main {
 }
 
 .btn-danger:hover {
-    background-color: #b91c1c;
+    background-color: var(--color-danger-hover);
 }
 
 /* === Modal 對話框 === */
@@ -694,7 +731,7 @@ main {
 
 .drop-zone.drag-over {
     border-color: var(--color-primary);
-    background-color: #eff6ff;
+    background-color: var(--color-dropzone-active);
 }
 
 .drop-zone-link {

--- a/static/index.html
+++ b/static/index.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Image-To-Md-Editor</title>
     <link rel="stylesheet" href="/static/css/style.css">
+    <!-- 防止 Dark Mode 頁面閃白：在 CSS 載入後立即設定 data-theme -->
+    <script>
+        (function() {
+            var s = localStorage.getItem('theme-preference');
+            var d = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            document.documentElement.setAttribute('data-theme', s || (d ? 'dark' : 'light'));
+        })();
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
 </head>
@@ -15,6 +23,9 @@
             <a href="#/editor" class="nav-link" data-page="editor">Editor</a>
             <a href="#/browser" class="nav-link" data-page="browser">File Browser</a>
         </div>
+        <button class="btn btn-icon" id="btn-theme-toggle" title="切換深色/淺色主題" aria-label="切換主題">
+            <span id="theme-icon">🌙</span>
+        </button>
     </nav>
     <main>
         <div id="page-editor" class="page">
@@ -31,6 +42,7 @@
                         <button class="btn btn-icon" id="btn-prev" title="上一張">&lt;</button>
                         <span class="toolbar-filename" id="current-filename">—</span>
                         <button class="btn btn-icon" id="btn-next" title="下一張">&gt;</button>
+                        <button class="btn btn-icon" id="btn-grayscale" title="切換黑白顯示">◑</button>
                     </div>
                     <div class="image-preview" id="image-preview">
                         <img id="preview-image" alt="圖片預覽" />
@@ -122,6 +134,7 @@
     <script src="/static/js/cropper.js"></script>
     <script src="/static/js/search.js"></script>
     <script src="/static/js/browser.js"></script>
+    <script src="/static/js/theme.js"></script>
     <script src="/static/js/app.js"></script>
 </body>
 </html>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2,6 +2,7 @@
  * 應用程式主進入點
  */
 document.addEventListener('DOMContentLoaded', () => {
+    Theme.init();
     Router.init();
     Editor.init();
     Cropper.init();

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -7,6 +7,7 @@ const Editor = (() => {
     let currentIndex = -1;
     let savedMarkdown = '';
     let previewMode = false;
+    let invertEnabled = false;
 
     const els = {};
 
@@ -21,6 +22,7 @@ const Editor = (() => {
         els.ocrBtn = document.getElementById('btn-ocr');
         els.previewBtn = document.getElementById('btn-preview');
         els.mdPreview = document.getElementById('md-preview');
+        els.grayscaleBtn = document.getElementById('btn-grayscale');
     }
 
     async function loadImageList() {
@@ -93,6 +95,7 @@ const Editor = (() => {
         const info = images[currentIndex];
         els.image.src = `/data/images/${info.filename}`;
         els.image.alt = info.filename;
+        els.image.classList.toggle('inverted', invertEnabled);
 
         updateToolbar();
 
@@ -142,6 +145,12 @@ const Editor = (() => {
         }
     }
 
+    function toggleInvert() {
+        invertEnabled = !invertEnabled;
+        els.image.classList.toggle('inverted', invertEnabled);
+        els.grayscaleBtn.classList.toggle('active', invertEnabled);
+    }
+
     let ocrAvailable = true;
 
     async function checkOcrStatus() {
@@ -189,6 +198,7 @@ const Editor = (() => {
         els.saveBtn.addEventListener('click', save);
         els.ocrBtn.addEventListener('click', ocr);
         els.previewBtn.addEventListener('click', togglePreview);
+        els.grayscaleBtn.addEventListener('click', toggleInvert);
 
         els.mdEditor.addEventListener('input', updateSaveBtn);
 

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -1,0 +1,44 @@
+/**
+ * 主題模組
+ * 負責 Dark/Light Mode 切換、localStorage 持久化、系統偏好自動偵測
+ */
+const Theme = (() => {
+    const STORAGE_KEY = 'theme-preference';
+    const els = {};
+
+    function getPreferredTheme() {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored === 'dark' || stored === 'light') return stored;
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+
+    function applyTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+        // Dark Mode 時顯示 ☀️（代表點擊後切回 Light）；Light Mode 時顯示 🌙
+        els.icon.textContent = theme === 'dark' ? '☀️' : '🌙';
+    }
+
+    function toggle() {
+        const current = document.documentElement.getAttribute('data-theme');
+        const next = current === 'dark' ? 'light' : 'dark';
+        localStorage.setItem(STORAGE_KEY, next);
+        applyTheme(next);
+    }
+
+    function init() {
+        els.btn = document.getElementById('btn-theme-toggle');
+        els.icon = document.getElementById('theme-icon');
+        els.btn.addEventListener('click', toggle);
+        // FOUC 防止 script 已設定 data-theme attribute，這裡只需同步 icon 狀態
+        const current = document.documentElement.getAttribute('data-theme') || getPreferredTheme();
+        applyTheme(current);
+        // 監聽系統偏好變更（僅在使用者未手動設定時生效）
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+            if (!localStorage.getItem(STORAGE_KEY)) {
+                applyTheme(e.matches ? 'dark' : 'light');
+            }
+        });
+    }
+
+    return { init };
+})();


### PR DESCRIPTION
## 摘要

- 整站 Dark/Light Mode 主題切換，偏好設定儲存至 `localStorage`，並自動偵測系統 `prefers-color-scheme`
- 左側圖片 Panel 新增色彩反轉按鈕（黑變白、白變黑），使用 CSS `filter: invert(1)` 純前端實作
- 新增 FOUC 防止機制，避免深色模式使用者看到頁面閃白

## 變更檔案

| 檔案 | 說明 |
|------|------|
| `static/css/style.css` | 新增 `[data-theme="dark"]` CSS 變數覆蓋；替換 3 處硬編碼色值；新增 `.inverted` filter |
| `static/index.html` | 加入 FOUC inline script；Navbar 主題切換按鈕；左 Panel ◑ 反轉按鈕；引入 theme.js |
| `static/js/theme.js` | 新增主題管理 IIFE 模組 |
| `static/js/editor.js` | 加入 `toggleInvert()` 邏輯，切換圖片時保持反轉狀態 |
| `static/js/app.js` | 加入 `Theme.init()` 最優先初始化 |

## 測試清單

- [ ] 點擊 🌙 按鈕切換深色主題，圖示變為 ☀️
- [ ] 重新整理頁面，主題保持（localStorage 持久化）
- [ ] 瀏覽器 DevTools 模擬 `prefers-color-scheme: dark`，首次載入自動套用
- [ ] 深色模式下各元件（table hover、type badge、drop zone）色彩正確
- [ ] 點擊 ◑ 按鈕，圖片色彩反轉（黑白互換），有 0.3s 漸變動畫
- [ ] 切換到下一張圖片，反轉狀態保持
- [ ] 框選裁切後 Ctrl+V 貼入的圖片為彩色原圖