### PR TITLE
feat: 響應式設計（Responsive Layout）

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -751,3 +751,116 @@ main {
     font-weight: 500;
     min-height: 1.3em;
 }
+
+/* === 行動版 Tab 列（預設隱藏） === */
+.mobile-tabs {
+    display: none;
+    flex-shrink: 0;
+}
+
+/* === 響應式設計 === */
+
+/* --- 中等螢幕：768–1023px --- */
+@media (min-width: 768px) and (max-width: 1023px) {
+    .editor-layout .panel-left {
+        flex: 0 0 40%;
+    }
+
+    .editor-layout .panel-right {
+        flex: 0 0 60%;
+    }
+}
+
+/* --- 小螢幕：< 768px --- */
+@media (max-width: 767px) {
+    /* Navbar 緊縮 */
+    .navbar {
+        padding: 0 12px;
+    }
+
+    .navbar-brand {
+        font-size: 1rem;
+    }
+
+    .nav-link {
+        padding: 6px 10px;
+        font-size: 0.8rem;
+    }
+
+    /* 頁面 padding 縮小 */
+    .page {
+        padding: 12px;
+    }
+
+    #page-editor.active {
+        padding: 0;
+    }
+
+    /* 行動版 Tab 列顯示 */
+    .mobile-tabs {
+        display: flex;
+        background-color: var(--color-surface);
+        border-bottom: 1px solid var(--color-border);
+    }
+
+    .mobile-tab {
+        flex: 1;
+        padding: 10px 0;
+        border: none;
+        background: none;
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        border-bottom: 2px solid transparent;
+        transition: color 0.15s, border-color 0.15s;
+    }
+
+    .mobile-tab:hover {
+        color: var(--color-text);
+    }
+
+    .mobile-tab.active {
+        color: var(--color-primary);
+        border-bottom-color: var(--color-primary);
+    }
+
+    /* 編輯器面板上下堆疊 */
+    .editor-layout {
+        flex-direction: column;
+    }
+
+    .editor-layout .panel {
+        flex: 1;
+        min-height: 0;
+    }
+
+    /* 預設隱藏非活躍面板 */
+    .editor-layout .panel.mobile-hidden {
+        display: none;
+    }
+
+    /* 檔案瀏覽器表格：隱藏「關聯」欄 */
+    .browser-table th:nth-child(3),
+    .browser-table td:nth-child(3) {
+        display: none;
+    }
+
+    /* 表格欄位 padding 縮小 */
+    .browser-table th,
+    .browser-table td {
+        padding: 8px 10px;
+    }
+
+    /* 檔案瀏覽器標題區 */
+    .browser-header {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    /* Modal 適配 */
+    .modal {
+        margin: 0 12px;
+        max-width: none;
+    }
+}

--- a/static/index.html
+++ b/static/index.html
@@ -36,6 +36,10 @@
                 <button class="btn-icon" id="search-next" title="下一個 (Enter)">&#9660;</button>
                 <button class="btn-icon" id="search-close" title="關閉 (Esc)">&#10005;</button>
             </div>
+            <div class="mobile-tabs" id="mobile-tabs">
+                <button class="mobile-tab active" data-panel="left">📷 圖片</button>
+                <button class="mobile-tab" data-panel="right">📝 編輯器</button>
+            </div>
             <div class="editor-layout">
                 <div class="panel panel-left">
                     <div class="panel-toolbar">
@@ -135,6 +139,7 @@
     <script src="/static/js/search.js"></script>
     <script src="/static/js/browser.js"></script>
     <script src="/static/js/theme.js"></script>
+    <script src="/static/js/responsive.js"></script>
     <script src="/static/js/app.js"></script>
 </body>
 </html>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -8,4 +8,5 @@ document.addEventListener('DOMContentLoaded', () => {
     Cropper.init();
     Searcher.init();
     Browser.init();
+    Responsive.init();
 });

--- a/static/js/responsive.js
+++ b/static/js/responsive.js
@@ -1,0 +1,58 @@
+/**
+ * 響應式設計模組
+ * 負責小螢幕下的圖片/編輯器 Tab 切換
+ */
+const Responsive = (() => {
+    const MOBILE_BREAKPOINT = 768;
+
+    let panelLeft;
+    let panelRight;
+    let tabContainer;
+    let tabs;
+    let activePanel = 'left';
+
+    function isMobile() {
+        return window.innerWidth < MOBILE_BREAKPOINT;
+    }
+
+    function applyMobileState() {
+        if (isMobile()) {
+            if (activePanel === 'left') {
+                panelLeft.classList.remove('mobile-hidden');
+                panelRight.classList.add('mobile-hidden');
+            } else {
+                panelLeft.classList.add('mobile-hidden');
+                panelRight.classList.remove('mobile-hidden');
+            }
+        } else {
+            panelLeft.classList.remove('mobile-hidden');
+            panelRight.classList.remove('mobile-hidden');
+        }
+    }
+
+    function switchTab(panel) {
+        activePanel = panel;
+
+        tabs.forEach(tab => {
+            tab.classList.toggle('active', tab.dataset.panel === panel);
+        });
+
+        applyMobileState();
+    }
+
+    function init() {
+        panelLeft = document.querySelector('.panel-left');
+        panelRight = document.querySelector('.panel-right');
+        tabContainer = document.getElementById('mobile-tabs');
+        tabs = tabContainer.querySelectorAll('.mobile-tab');
+
+        tabs.forEach(tab => {
+            tab.addEventListener('click', () => switchTab(tab.dataset.panel));
+        });
+
+        window.addEventListener('resize', applyMobileState);
+        applyMobileState();
+    }
+
+    return { init };
+})();


### PR DESCRIPTION
## 功能說明

為編輯器頁面與檔案瀏覽器頁面加入響應式設計，適配不同螢幕寬度。

## 變更內容

- **≥ 1024px** — 左右對開雙面板各佔 50%（原有行為不變）
- **768–1023px** — 左面板 40% / 右面板 60%
- **< 768px** — 上下堆疊，圖片與編輯器以 Tab 切換
- 檔案瀏覽器表格在小螢幕下隱藏「關聯」欄並縮減間距
- 新增 `Responsive` 模組處理 Tab 切換與視窗尺寸變化

## 異動檔案

- `static/index.html` — 加入行動版 Tab 切換列
- `static/css/style.css` — 加入三段 media query 響應式規則
- `static/js/responsive.js` — 新增 Responsive 模組
- `static/js/app.js` — 初始化 Responsive 模組

Closes #13